### PR TITLE
Use default-binder repository

### DIFF
--- a/ECS_Gregory_method.ipynb
+++ b/ECS_Gregory_method.ipynb
@@ -490,7 +490,9 @@
     "ds_abrupt = ds_anom.sel(year=first_150_years, experiment_id='abrupt-4xCO2').reset_coords(drop=True)\n",
     "\n",
     "def calc_ecs(ds):\n",
-    "    a, b = np.polyfit(ds.tas, ds.imbalance, 1)\n",
+    "    # Some sources don't have all 150 years, drop those missing values.\n",
+    "    a, b = np.polyfit(ds.tas.dropna(\"year\"),\n",
+    "                      ds.imbalance.dropna(\"year\"), 1)\n",
     "    ecs = -0.5 * (b/a)\n",
     "    return xr.DataArray(ecs)\n",
     "\n",
@@ -514,6 +516,8 @@
     "fg = ds_abrupt.plot.scatter(x='tas', y='imbalance', col='source_id', col_wrap=5)\n",
     "\n",
     "def calc_and_plot_ecs(x, y, **kwargs):\n",
+    "    x = x[~np.isnan(x)]\n",
+    "    y = y[~np.isnan(y)]\n",
     "    a, b = np.polyfit(x, y, 1)\n",
     "    ecs = -0.5 * b/a\n",
     "    plt.autoscale(False)\n",
@@ -541,13 +545,6 @@
    "source": [
     "ds_abrupt.ecs.to_dataframe().sort_values('ecs').plot(kind='bar')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -566,7 +563,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -4,6 +4,6 @@ description: >-
   Examples of analysis of Google Cloud CMIP6 data using Pangeo tools.
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://binder.pangeo.io"
-binder_repo: pangeo-gallery/cmip6
-binder_ref: binder
+binder_repo: pangeo-gallery/default-binder
+binder_ref: master
 binderbot_target_branch: binderbot-built

--- a/global_mean_surface_temp.ipynb
+++ b/global_mean_surface_temp.ipynb
@@ -205,7 +205,7 @@
    "source": [
     "sns.relplot(data=df_all,\n",
     "            x=\"year\", y=\"tas\", hue='experiment_id',\n",
-    "            kind=\"line\", ci=\"sd\", size=10, aspect=2);"
+    "            kind=\"line\", ci=\"sd\", aspect=2);"
    ]
   },
   {
@@ -217,13 +217,6 @@
     "# why are there axis legends for 9, 10 - doesn't make sense\n",
     "df_all.experiment_id.unique()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -242,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
AFAICT, the only differences are moving the base Dockerfile and pangeo-notebook images forward to 2020.08.31.

```
pangeo-notebook=2020.04.28 -> pangeo-notebook=2020.08.31
```

Using the default-binder image will make testing deployments of the binderhub a bit easier.