### PR TITLE
added seaborn in correct alphabetical order

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -45,6 +45,7 @@ dependencies:
  - scikit-image
  - scikit-learn
  - scipy
+ - seaborn
  - sparse
  - tiledb-py
  - xarray


### PR DESCRIPTION
https://github.com/pangeo-gallery/cmip6/blob/master/global_mean_surface_temp.ipynb 
doesn't run without seaborn lib. binderbot points to this env file.